### PR TITLE
Adaptar paquete para remover recursos generados para Websocket

### DIFF
--- a/lib/serverless-plugin-remove-authorizer-permissions.js
+++ b/lib/serverless-plugin-remove-authorizer-permissions.js
@@ -21,7 +21,7 @@ class ServerlessPluginRemoveAuthorizerPermissions {
 
 		Object.keys(template.Resources).forEach(resourceName => {
 
-			if(resourceName.match(/AuthorizerLambdaPermissionApiGateway$/)) {
+			if(resourceName.match(/AuthorizerLambdaPermissionApiGateway$/) || resourceName.match(/AuthorizerLambdaPermissionWebsockets$/)) {
 				delete template.Resources[resourceName];
 				removedResources.push(resourceName);
 			}

--- a/tests/serverless-plugin-remove-authorizer-permissions-test.js
+++ b/tests/serverless-plugin-remove-authorizer-permissions-test.js
@@ -48,6 +48,7 @@ describe('ServerlessPluginRemoveAuthorizerPermissions', () => {
 		const testConfig = cloneDeep(serverless);
 		testConfig.service.provider.compiledCloudFormationTemplate.Resources.MyAuthorizerLambdaPermissionApiGateway = {};
 		testConfig.service.provider.compiledCloudFormationTemplate.Resources.SomeOtherAuthorizerLambdaPermissionApiGateway = {};
+		testConfig.service.provider.compiledCloudFormationTemplate.Resources.SomeOtherAuthorizerLambdaPermissionWebsockets = {};
 
 		const serverlessPluginRemoveAuthorizerPermissions = new ServerlessPluginRemoveAuthorizerPermissions(testConfig);
 		serverlessPluginRemoveAuthorizerPermissions.removePermissions();


### PR DESCRIPTION
### Link al ticket

[Historia](https://janiscommerce.atlassian.net/browse/JPACK-85)

[Subtarea](https://janiscommerce.atlassian.net/browse/JPACK-86)

### Descripción del requerimiento

El paquete debe borrar los permisos generados para websocket

### Descripción de la solución
Se sumo una condicion mas para que se eliminen los recursos que coinciden con `AuthorizerLambdaPermissionWebsockets`